### PR TITLE
Set language for correct printf in check_open_files

### DIFF
--- a/plugins/check_open_files
+++ b/plugins/check_open_files
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+LANG=C
+LC_NUMERIC=C
+
 OUTPUT=`cat /proc/sys/fs/file-nr 2>/dev/null`
 ret=$?
 


### PR DESCRIPTION
printf will fail when server's language environment is configured for decimal separator different to '.'